### PR TITLE
feat(http_mock_adapter): Exported MockServer and callback definitions

### DIFF
--- a/lib/http_mock_adapter.dart
+++ b/lib/http_mock_adapter.dart
@@ -1,7 +1,9 @@
 export 'src/adapters/dio_adapter.dart';
 export 'src/exceptions.dart' show MockDioException;
 export 'src/extensions/matches_request.dart';
+export 'src/handlers/request_handler.dart';
 export 'src/interceptors/dio_interceptor.dart';
 export 'src/matchers/http_matcher.dart';
 export 'src/matchers/matchers.dart';
 export 'src/request.dart' show Request, RequestMethods;
+export 'src/types.dart';


### PR DESCRIPTION
Hi,

this library is helping me to write elegant tests, thanks!


I've noticed that some definitions aren't exported. Most notably the `MockServer` definition. I've exported such definitions so external libraries can better work with HttpMockAdapter.

For instance:
`adapter.onGet("/dashboard", (server) => server.reply(HttpStatus.internalServerError, {}));`

here the `server` argument itself is of type `MockServer`. But as this type is not exported, there is no way to keep a `MockServer` instance in dart because the class itself can't be accessed.
This pr fixes that